### PR TITLE
Update AverageRecommendationMetric.java

### DIFF
--- a/RankSys-metrics/src/main/java/es/uam/eps/ir/ranksys/metrics/basic/AverageRecommendationMetric.java
+++ b/RankSys-metrics/src/main/java/es/uam/eps/ir/ranksys/metrics/basic/AverageRecommendationMetric.java
@@ -81,7 +81,9 @@ public class AverageRecommendationMetric<U, I> extends AbstractSystemMetric<U, I
         double v = metric.evaluate(recommendation);
 
         if (!ignoreNaN || !Double.isNaN(v)) {
-            sum += v;
+            if (!Double.isNaN(v)) {
+                sum += v;
+            }
 
             if (!allUsers) {
                 numUsers++;


### PR DESCRIPTION
In the original version, when ignoreNaN is false, no matter whether v is NaN or not, it will enter into the for block.
If v is NaN, "sum+=v;" will make sum equal to NaN. But in fact, we should treat NaN as zero -- making no contributions (sum += 0 doesn't change sum) -- when ignoreNaN is false. 
So we only need to execute the statement "sum += v;" when v is not NaN.
