### PR TITLE
UserModel - if user is not cached, getModel returns null

### DIFF
--- a/RankSys-core/src/main/java/es/uam/eps/ir/ranksys/core/model/UserModel.java
+++ b/RankSys-core/src/main/java/es/uam/eps/ir/ranksys/core/model/UserModel.java
@@ -100,7 +100,7 @@ public abstract class UserModel<U> {
      * @return a user model
      */
     public Model<U> getModel(U u) {
-        if (caching) {
+        if (caching && lazyUserMap.get().containsKey(u)) {
             return lazyUserMap.get().get(u);
         } else {
             return get(u);


### PR DESCRIPTION
If user is not cached (e.g. because it didn't exist in the targetUser stream) getModel returns null. Instead of that model could be created.

Probably it would be nice to add it as well to the cache after creating.
