### PR TITLE
squid:S1941,squid:S1213 - Multiple quality improvements

### DIFF
--- a/RankSys-compression/src/main/java/org/ranksys/compression/preferences/BinaryCODECPreferenceData.java
+++ b/RankSys-compression/src/main/java/org/ranksys/compression/preferences/BinaryCODECPreferenceData.java
@@ -46,6 +46,23 @@ import static org.ranksys.core.util.tuples.Tuples.tuple;
 public class BinaryCODECPreferenceData<U, I, Cu, Ci> extends AbstractCODECPreferenceData<U, I, Cu, Ci> {
 
     /**
+     * Constructor using streams of user and items preferences lists.
+     *
+     * @param ul stream of user preferences lists
+     * @param il stream of item preferences lists
+     * @param users user index
+     * @param items item index
+     * @param u_codec user preferences list CODEC
+     * @param i_codec item preferences list CODEC
+     */
+    public BinaryCODECPreferenceData(Stream<Tuple2io<int[]>> ul, Stream<Tuple2io<int[]>> il, FastUserIndex<U> users, FastItemIndex<I> items, CODEC<Cu> u_codec, CODEC<Ci> i_codec) {
+        super(users, items, u_codec, i_codec);
+
+        index(ul, u_idxs, u_len, u_codec);
+        index(il, i_idxs, i_len, i_codec);
+    }
+
+    /**
      * Constructor that utilizes other PreferenceData object.
      *
      * @param preferences input preference data to be copied
@@ -73,23 +90,6 @@ public class BinaryCODECPreferenceData<U, I, Cu, Ci> extends AbstractCODECPrefer
 
     private static Stream<Tuple2io<int[]>> il(FastPreferenceData<?, ?> preferences) {
         return ul(new TransposedPreferenceData<>(preferences));
-    }
-
-    /**
-     * Constructor using streams of user and items preferences lists.
-     *
-     * @param ul stream of user preferences lists
-     * @param il stream of item preferences lists
-     * @param users user index
-     * @param items item index
-     * @param u_codec user preferences list CODEC
-     * @param i_codec item preferences list CODEC
-     */
-    public BinaryCODECPreferenceData(Stream<Tuple2io<int[]>> ul, Stream<Tuple2io<int[]>> il, FastUserIndex<U> users, FastItemIndex<I> items, CODEC<Cu> u_codec, CODEC<Ci> i_codec) {
-        super(users, items, u_codec, i_codec);
-
-        index(ul, u_idxs, u_len, u_codec);
-        index(il, i_idxs, i_len, i_codec);
     }
 
     private static <Cx> void index(Stream<Tuple2io<int[]>> lists, Cx[] idxs, int[] lens, CODEC<Cx> x_codec) {

--- a/RankSys-compression/src/main/java/org/ranksys/compression/preferences/RatingCODECPreferenceData.java
+++ b/RankSys-compression/src/main/java/org/ranksys/compression/preferences/RatingCODECPreferenceData.java
@@ -67,25 +67,6 @@ public class RatingCODECPreferenceData<U, I, Cu, Ci, Cv> extends AbstractCODECPr
         this(ul(preferences), il(preferences), users, items, u_codec, i_codec, r_codec);
     }
 
-    private static Stream<Tuple2io<int[][]>> ul(FastPreferenceData<?, ?> preferences) {
-        return preferences.getUidxWithPreferences().mapToObj(k -> {
-            IdxPref[] pairs = preferences.getUidxPreferences(k)
-                    .sorted((p1, p2) -> Integer.compare(p1.v1, p2.v1))
-                    .toArray(n -> new IdxPref[n]);
-            int[] idxs = new int[pairs.length];
-            int[] vs = new int[pairs.length];
-            for (int i = 0; i < pairs.length; i++) {
-                idxs[i] = pairs[i].v1;
-                vs[i] = (int) pairs[i].v2;
-            }
-            return tuple(k, new int[][]{idxs, vs});
-        });
-    }
-
-    private static Stream<Tuple2io<int[][]>> il(FastPreferenceData<?, ?> preferences) {
-        return ul(new TransposedPreferenceData<>(preferences));
-    }
-
     /**
      * Constructor using streams of user and items preferences lists.
      *
@@ -107,6 +88,25 @@ public class RatingCODECPreferenceData<U, I, Cu, Ci, Cv> extends AbstractCODECPr
 
         index(ul, u_idxs, u_vs, u_len, u_codec, r_codec);
         index(il, i_idxs, i_vs, i_len, i_codec, r_codec);
+    }
+
+    private static Stream<Tuple2io<int[][]>> ul(FastPreferenceData<?, ?> preferences) {
+        return preferences.getUidxWithPreferences().mapToObj(k -> {
+            IdxPref[] pairs = preferences.getUidxPreferences(k)
+                    .sorted((p1, p2) -> Integer.compare(p1.v1, p2.v1))
+                    .toArray(n -> new IdxPref[n]);
+            int[] idxs = new int[pairs.length];
+            int[] vs = new int[pairs.length];
+            for (int i = 0; i < pairs.length; i++) {
+                idxs[i] = pairs[i].v1;
+                vs[i] = (int) pairs[i].v2;
+            }
+            return tuple(k, new int[][]{idxs, vs});
+        });
+    }
+
+    private static Stream<Tuple2io<int[][]>> il(FastPreferenceData<?, ?> preferences) {
+        return ul(new TransposedPreferenceData<>(preferences));
     }
 
     private static <Cx, Cv> void index(Stream<Tuple2io<int[][]>> lists, Cx[] idxs, Cv[] vs, int[] lens, CODEC<Cx> x_codec, CODEC<Cv> r_codec) {

--- a/RankSys-core/src/main/java/es/uam/eps/ir/ranksys/core/util/topn/AbstractTopN.java
+++ b/RankSys-core/src/main/java/es/uam/eps/ir/ranksys/core/util/topn/AbstractTopN.java
@@ -214,11 +214,12 @@ public abstract class AbstractTopN<T> extends AbstractCollection<T> {
 
     private int minChild(int i) {
         int l = left(i);
-        int r = right(i);
 
         if (l >= capacity) {
             return -1;
         }
+
+        int r = right(i);
 
         if (r >= size) {
             return l;

--- a/RankSys-diversity/src/main/java/es/uam/eps/ir/ranksys/diversity/binom/BinomialModel.java
+++ b/RankSys-diversity/src/main/java/es/uam/eps/ir/ranksys/diversity/binom/BinomialModel.java
@@ -168,8 +168,7 @@ public class BinomialModel<U, I, F> extends UserModel<U> {
             
             Object2DoubleOpenHashMap<F> probs = new Object2DoubleOpenHashMap<>();
             probs.defaultReturnValue(0.0);
-            
-            int n = recommenderData.numItems(user);
+
             recommenderData.getUserPreferences(user).forEach(pref -> {
                 featureData.getItemFeatures(pref.v1).forEach(feature -> {
                     probs.addTo(feature.v1, 1.0);
@@ -179,7 +178,8 @@ public class BinomialModel<U, I, F> extends UserModel<U> {
             if (probs.isEmpty()) {
                 return globalFeatureProbs;
             }
-            
+
+            int n = recommenderData.numItems(user);
             if (alpha < 1.0) {
                 globalFeatureProbs.object2DoubleEntrySet().forEach(e -> {
                     F f = e.getKey();

--- a/RankSys-examples/src/main/java/es/uam/eps/ir/ranksys/examples/RecommenderExample.java
+++ b/RankSys-examples/src/main/java/es/uam/eps/ir/ranksys/examples/RecommenderExample.java
@@ -73,7 +73,6 @@ public class RecommenderExample {
         FastUserIndex<Long> userIndex = SimpleFastUserIndex.load(UsersReader.read(userPath, lp));
         FastItemIndex<Long> itemIndex = SimpleFastItemIndex.load(ItemsReader.read(itemPath, lp));
         FastPreferenceData<Long, Long> trainData = SimpleFastPreferenceData.load(SimpleRatingPreferencesReader.get().read(trainDataPath, lp, lp), userIndex, itemIndex);
-        FastPreferenceData<Long, Long> testData = SimpleFastPreferenceData.load(SimpleRatingPreferencesReader.get().read(testDataPath, lp, lp), userIndex, itemIndex);
 
         //////////////////
         // RECOMMENDERS //
@@ -167,6 +166,7 @@ public class RecommenderExample {
         ////////////////////////////////
         // GENERATING RECOMMENDATIONS //
         ////////////////////////////////
+        FastPreferenceData<Long, Long> testData = SimpleFastPreferenceData.load(SimpleRatingPreferencesReader.get().read(testDataPath, lp, lp), userIndex, itemIndex);
         Set<Long> targetUsers = testData.getUsersWithPreferences().collect(Collectors.toSet());
         RecommendationFormat<Long, Long> format = new SimpleRecommendationFormat<>(lp, lp);
         Function<Long, IntPredicate> filter = FastFilters.notInTrain(trainData);

--- a/RankSys-examples/src/main/java/es/uam/eps/ir/ranksys/examples/RerankerExample.java
+++ b/RankSys-examples/src/main/java/es/uam/eps/ir/ranksys/examples/RerankerExample.java
@@ -41,15 +41,14 @@ public class RerankerExample {
     public static void main(String[] args) throws Exception {
         String trainDataPath = args[0];
         String featurePath = args[1];
-        String recIn = args[2];
 
         double lambda = 0.5;
         int cutoff = 100;
         PreferenceData<Long, Long> trainData = SimplePreferenceData.load(SimpleRatingPreferencesReader.get().read(trainDataPath, lp, lp));
-        FeatureData<Long, String, Double> featureData = SimpleFeatureData.load(SimpleFeaturesReader.get().read(featurePath, lp, sp));
 
         Map<String, Supplier<Reranker<Long, Long>>> rerankersMap = new HashMap<>();
 
+        FeatureData<Long, String, Double> featureData = SimpleFeatureData.load(SimpleFeaturesReader.get().read(featurePath, lp, sp));
         rerankersMap.put("MMR", () -> {
             ItemDistanceModel<Long> dist = new JaccardFeatureItemDistanceModel<>(featureData);
             return new MMR<>(lambda, cutoff, dist);
@@ -64,6 +63,7 @@ public class RerankerExample {
 
         rerankersMap.forEach(Unchecked.biConsumer((name, rerankerSupplier) -> {
             System.out.println("Running " + name);
+            String recIn = args[2];
             String recOut = String.format("%s_%s", recIn, name);
             Reranker<Long, Long> reranker = rerankerSupplier.get();
             try (RecommendationFormat.Writer<Long, Long> writer = format.getWriter(recOut)) {

--- a/RankSys-formats/src/main/java/org/ranksys/formats/factorization/SimpleFactorizationFormat.java
+++ b/RankSys-formats/src/main/java/org/ranksys/formats/factorization/SimpleFactorizationFormat.java
@@ -25,11 +25,11 @@ import static java.lang.Integer.parseInt;
  */
 public class SimpleFactorizationFormat implements FactorizationFormat {
 
-    public static SimpleFactorizationFormat get() {
-        return new SimpleFactorizationFormat();
+    private SimpleFactorizationFormat() {
     }
 
-    private SimpleFactorizationFormat() {
+    public static SimpleFactorizationFormat get() {
+        return new SimpleFactorizationFormat();
     }
 
     private static void saveDenseDoubleMatrix2D(OutputStream stream, DenseDoubleMatrix2D matrix) throws IOException {

--- a/RankSys-formats/src/main/java/org/ranksys/formats/feature/SimpleFeaturesReader.java
+++ b/RankSys-formats/src/main/java/org/ranksys/formats/feature/SimpleFeaturesReader.java
@@ -16,11 +16,11 @@ import org.ranksys.formats.parsing.Parser;
  */
 public class SimpleFeaturesReader implements FeaturesReader {
 
-    public static <I, F> SimpleFeaturesReader get() {
-        return new SimpleFeaturesReader();
+    private SimpleFeaturesReader() {
     }
 
-    private SimpleFeaturesReader() {
+    public static <I, F> SimpleFeaturesReader get() {
+        return new SimpleFeaturesReader();
     }
 
     @Override

--- a/RankSys-formats/src/main/java/org/ranksys/formats/preference/SimpleBinaryPreferencesReader.java
+++ b/RankSys-formats/src/main/java/org/ranksys/formats/preference/SimpleBinaryPreferencesReader.java
@@ -16,11 +16,11 @@ import org.ranksys.formats.parsing.Parser;
  */
 public class SimpleBinaryPreferencesReader implements PreferencesReader {
 
-    public static <U, I> SimpleBinaryPreferencesReader get() {
-        return new SimpleBinaryPreferencesReader();
+    private SimpleBinaryPreferencesReader() {
     }
 
-    private SimpleBinaryPreferencesReader() {
+    public static <U, I> SimpleBinaryPreferencesReader get() {
+        return new SimpleBinaryPreferencesReader();
     }
 
     @Override

--- a/RankSys-formats/src/main/java/org/ranksys/formats/preference/SimpleRatingPreferencesReader.java
+++ b/RankSys-formats/src/main/java/org/ranksys/formats/preference/SimpleRatingPreferencesReader.java
@@ -17,11 +17,11 @@ import org.ranksys.formats.parsing.Parser;
  */
 public class SimpleRatingPreferencesReader implements PreferencesReader {
 
-    public static <U, I> SimpleRatingPreferencesReader get() {
-        return new SimpleRatingPreferencesReader();
+    private SimpleRatingPreferencesReader() {
     }
 
-    private SimpleRatingPreferencesReader() {
+    public static <U, I> SimpleRatingPreferencesReader get() {
+        return new SimpleRatingPreferencesReader();
     }
 
     @Override

--- a/RankSys-formats/src/main/java/org/ranksys/formats/rec/MahoutRecommendationFormat.java
+++ b/RankSys-formats/src/main/java/org/ranksys/formats/rec/MahoutRecommendationFormat.java
@@ -115,8 +115,6 @@ public class MahoutRecommendationFormat<U, I> implements RecommendationFormat<U,
             return reader.lines().map(line -> {
                 CharSequence[] toks1 = split(line, '\t');
 
-                U user = uParser.parse(toks1[0]);
-
                 CharSequence[] toks2 = split(toks1[1].subSequence(1, toks1[1].length() - 1), ',');
                 List<Tuple2od<I>> items = Stream.of(toks2).map(is -> {
                     CharSequence[] toks3 = split(is, ':');
@@ -126,7 +124,7 @@ public class MahoutRecommendationFormat<U, I> implements RecommendationFormat<U,
 
                     return tuple(i, s);
                 }).collect(toList());
-
+                U user = uParser.parse(toks1[0]);
                 return new Recommendation<U, I>(user, items);
             });
         }

--- a/RankSys-metrics/src/main/java/es/uam/eps/ir/ranksys/metrics/basic/Recall.java
+++ b/RankSys-metrics/src/main/java/es/uam/eps/ir/ranksys/metrics/basic/Recall.java
@@ -52,7 +52,6 @@ public class Recall<U, I> extends AbstractRecommendationMetric<U, I> {
     @Override
     public double evaluate(Recommendation<U, I> recommendation) {
         U user = recommendation.getUser();
-        IdealRelevanceModel.UserIdealRelevanceModel<U, I> userRelModel = relModel.getModel(user);
 
         int numberOfAllRelevant = relModel.getModel(user).getRelevantItems().size();
 
@@ -60,6 +59,7 @@ public class Recall<U, I> extends AbstractRecommendationMetric<U, I> {
             return 0.0;
         }
 
+        IdealRelevanceModel.UserIdealRelevanceModel<U, I> userRelModel = relModel.getModel(user);
         return recommendation.getItems().stream()
                 .limit(cutoff)
                 .map(Tuple2od::v1)

--- a/RankSys-novdiv/src/main/java/es/uam/eps/ir/ranksys/novdiv/itemnovelty/metrics/ItemNoveltyMetric.java
+++ b/RankSys-novdiv/src/main/java/es/uam/eps/ir/ranksys/novdiv/itemnovelty/metrics/ItemNoveltyMetric.java
@@ -66,7 +66,6 @@ public abstract class ItemNoveltyMetric<U, I> extends AbstractRecommendationMetr
     @Override
     public double evaluate(Recommendation<U, I> recommendation) {
         U u = recommendation.getUser();
-        RelevanceModel.UserRelevanceModel<U, I> userRelModel = relModel.getModel(u);
         ItemNovelty.UserItemNoveltyModel<U, I> uinm = novelty.getModel(u);
         
         if (uinm == null) {
@@ -78,6 +77,7 @@ public abstract class ItemNoveltyMetric<U, I> extends AbstractRecommendationMetr
 
         int rank = 0;
         for (Tuple2od<I> iv : recommendation.getItems()) {
+            RelevanceModel.UserRelevanceModel<U, I> userRelModel = relModel.getModel(u);
             nov += disc.disc(rank) * userRelModel.gain(iv.v1) * uinm.novelty(iv.v1);
             norm += disc.disc(rank);
             rank++;

--- a/RankSys-novdiv/src/main/java/es/uam/eps/ir/ranksys/novdiv/itemnovelty/reranking/ItemNoveltyReranker.java
+++ b/RankSys-novdiv/src/main/java/es/uam/eps/ir/ranksys/novdiv/itemnovelty/reranking/ItemNoveltyReranker.java
@@ -52,7 +52,6 @@ public class ItemNoveltyReranker<U, I> extends PermutationReranker<U, I> {
 
     @Override
     public int[] rerankPermutation(Recommendation<U, I> recommendation, int maxLength) {
-        U user = recommendation.getUser();
         List<Tuple2od<I>> items = recommendation.getItems();
         int M = items.size();
         int N = min(maxLength, M);
@@ -61,6 +60,7 @@ public class ItemNoveltyReranker<U, I> extends PermutationReranker<U, I> {
             return getBasePerm(N);
         }
 
+        U user = recommendation.getUser();
         ItemNovelty.UserItemNoveltyModel<U, I> uinm = novelty.getModel(user);
         if (uinm == null) {
             return new int[0];


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1941 - Variables should not be declared before they are relevant
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1941
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat
